### PR TITLE
introduced options: -c, --response-timeout.

### DIFF
--- a/chocon.go
+++ b/chocon.go
@@ -136,7 +136,6 @@ Compiler: %s %s
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
 		// self-customized values
-		MaxIdleConns:          0,
 		MaxIdleConnsPerHost:   opts.KeepaliveConns,
 		ResponseHeaderTimeout: time.Duration(opts.ResponseTimeout) * time.Second,
 	}

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -37,10 +37,10 @@ type Proxy struct {
 }
 
 // Create a request-based reverse-proxy.
-func NewProxyWithRequestConverter(requestConverter func(*http.Request, *http.Request, *ProxyStatus)) *Proxy {
+func NewProxyWithRequestConverter(requestConverter func(*http.Request, *http.Request, *ProxyStatus), transport *http.RoundTripper) *Proxy {
 	return &Proxy{
 		RequestConverter: requestConverter,
-		Transport:        http.DefaultTransport,
+		Transport:        *transport,
 	}
 }
 


### PR DESCRIPTION
http.DefaultTransport sets the members such as MaxIdleConnsPerHost 2 and ResponseHeaderTimeout 0.

MaxIdleConnsPerHost is maximun count of keepalive connections for upstream.
If ResponseHeaderTimeout is zero, client is possible to be blocked when upstream slows down.