### PR TITLE
split host and port

### DIFF
--- a/chocon.go
+++ b/chocon.go
@@ -112,8 +112,12 @@ Compiler: %s %s
 			ps.Status = http.StatusBadRequest
 			return
 		}
-		originalHost := r.Host
-		hostSplited := strings.Split(originalHost, ".")
+		host, _, err := net.SplitHostPort(r.Host)
+		if err != nil {
+			ps.Status = http.StatusBadRequest
+			return
+		}
+		hostSplited := strings.Split(host, ".")
 		lastPartIndex := 0
 		for i, hostPart := range hostSplited {
 			if hostPart == "ccnproxy-ssl" || hostPart == "ccnproxy-secure" || hostPart == "ccnproxy-https" || hostPart == "ccnproxy" {


### PR DESCRIPTION
When I send a request to `foo.bar.com.ccnproxy-secure:3000`,  chocon handles the request host of last part as `ccnproxy-secure:3000`, then return BadRequest response.
Split host into honame and port number.