### PR TITLE
net.SplitHostPort raised error when r.Host did not have `:port`

### DIFF
--- a/chocon.go
+++ b/chocon.go
@@ -112,11 +112,7 @@ Compiler: %s %s
 			ps.Status = http.StatusBadRequest
 			return
 		}
-		host, _, err := net.SplitHostPort(r.Host)
-		if err != nil {
-			ps.Status = http.StatusBadRequest
-			return
-		}
+		host := strings.Split(r.Host, ":")[0]
 		hostSplited := strings.Split(host, ".")
 		lastPartIndex := 0
 		for i, hostPart := range hostSplited {


### PR DESCRIPTION
https://play.golang.org/p/G-VFyj-MhL

```
package main

import (
	"fmt"
	"net"
)

func main() {
	host, _, err := net.SplitHostPort("example.com");
	if err != nil {
		panic(err);
	}
	fmt.Printf("%v\n",host)
}

```

```
panic: address example.com: missing port in address

goroutine 1 [running]:
main.main()
	/tmp/sandbox152462670/main.go:11 +0x120

Program exited.
```