### PR TITLE
change variable names and the package names for golint

### DIFF
--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -1,14 +1,15 @@
-package proxy_handler
+package proxy
 
 // this class is based on https://github.com/r7kamura/entoverse
 
 import (
-	"github.com/renstrom/shortuuid"
 	"io"
 	"log"
 	"net"
 	"net/http"
 	"net/url"
+
+	"github.com/renstrom/shortuuid"
 )
 
 const (
@@ -53,8 +54,8 @@ func (proxy *Proxy) ServeHTTP(writer http.ResponseWriter, originalRequest *http.
 	}
 
 	// Set Proxied
-	proxy_id := shortuuid.New()
-	originalRequest.Header.Set(ProxyHeaderName, proxy_id)
+	proxyID := shortuuid.New()
+	originalRequest.Header.Set(ProxyHeaderName, proxyID)
 
 	// Create a new proxy request object by coping the original request.
 	proxyRequest := proxy.copyRequest(originalRequest)
@@ -89,7 +90,7 @@ func (proxy *Proxy) ServeHTTP(writer http.ResponseWriter, originalRequest *http.
 			writer.Header().Add(key, value)
 		}
 	}
-	writer.Header().Add(ProxyHeaderName, proxy_id)
+	writer.Header().Add(ProxyHeaderName, proxyID)
 
 	// Copy a status code.
 	writer.WriteHeader(response.StatusCode)
@@ -101,10 +102,10 @@ func (proxy *Proxy) ServeHTTP(writer http.ResponseWriter, originalRequest *http.
 // Create a new proxy request with some modifications from an original request.
 func (proxy *Proxy) copyRequest(originalRequest *http.Request) *http.Request {
 	proxyRequest := new(http.Request)
-	proxyUrl := new(url.URL)
+	proxyURL := new(url.URL)
 	*proxyRequest = *originalRequest
-	*proxyUrl = *originalRequest.URL
-	proxyRequest.URL = proxyUrl
+	*proxyURL = *originalRequest.URL
+	proxyRequest.URL = proxyURL
 	proxyRequest.Proto = "HTTP/1.1"
 	proxyRequest.ProtoMajor = 1
 	proxyRequest.ProtoMinor = 1


### PR DESCRIPTION
```
golint chocon.go

Before:
chocon.go:21:2: exported var Version should have comment or be unexported
chocon.go:46:36: don't use underscores in Go names; func parameter log_dir should be logDir
chocon.go:46:52: don't use underscores in Go names; func parameter log_rotate should be logRotate
chocon.go:47:2: don't use underscores in Go names; var apache_log should be apacheLog
chocon.go:66:2: don't use underscores in Go names; var log_file should be logFile
chocon.go:67:2: don't use underscores in Go names; var link_name should be linkName
chocon.go:69:3: don't use underscores in Go names; var log_file should be logFile
chocon.go:70:3: don't use underscores in Go names; var link_name should be linkName
chocon.go:73:2: don't use underscores in Go names; var log_file should be logFile
chocon.go:74:2: don't use underscores in Go names; var link_name should be linkName

After:
chocon.go:21:2: exported var Version should have comment or be unexported
```

```
golint handler.go

Before:
handler.go:1:1: don't use an underscore in package name
handler.go:15:2: exported const ProxyHeaderName should have comment (or a comment on this block) or be unexported
handler.go:30:6: exported type ProxyStatus should have comment or be unexported
handler.go:34:1: comment on exported type Proxy should be of the form "Proxy ..." (with optional leading article)
handler.go:40:1: comment on exported function NewProxyWithRequestConverter should be of the form "NewProxyWithRequestConverter ..."
handler.go:56:2: don't use underscores in Go names; var proxy_id should be proxyID
handler.go:104:2: var proxyUrl should be proxyURL

After:
handler.go:16:2: exported const ProxyHeaderName should have comment (or a comment on this block) or be unexported
handler.go:31:6: exported type ProxyStatus should have comment or be unexported
handler.go:31:6: type name will be used as proxy.ProxyStatus by other packages, and that stutters; consider calling this Status
handler.go:35:1: comment on exported type Proxy should be of the form "Proxy ..." (with optional leading article)
handler.go:41:1: comment on exported function NewProxyWithRequestConverter should be of the form "NewProxyWithRequestConverter ..."
```

cf: https://github.com/golang/lint
cf: https://golang.org/doc/effective_go.html