### PR TITLE
optimize: made ignoredHeaderNames map.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,9 @@ chocon: chocon.go
 linux: chocon.go
 	GOOS=linux GOARCH=amd64 go build $(LDFLAGS) chocon.go
 
+check:
+	go test -v $(TARGETS_NOVENDOR)
+
 fmt:
 	@echo $(TARGETS_NOVENDOR) | xargs go fmt
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,40 +1,34 @@
-hash: 8776b72b857522095fe1b5a7f38ac157c6cc71f8cd3d410ce6cf05bbe46c1a64
-updated: 2017-01-26T20:24:29.7292639+09:00
+hash: 9f27eda7c264bb4031d57a6300ad0d3fead43308b537e1be96f23e94b36be412
+updated: 2017-06-14T12:41:19.942947125-07:00
 imports:
 - name: github.com/fukata/golang-stats-api-handler
   version: ab9f90f16caab828afda479fd34bfbbbba2efcee
-  subpackages:
-  - github.com/fukata/golang-stats-api-handler
 - name: github.com/jessevdk/go-flags
   version: 4e64e4a4e2552194cf594243e23aa9baf3b4297e
-  subpackages:
-  - github.com/jessevdk/go-flags
 - name: github.com/lestrrat/go-apache-logformat
   version: aef9f5955f335dc2fbb969c95b849347b15e36c9
-  subpackages:
-  - github.com/lestrrat/go-apache-logformat
 - name: github.com/lestrrat/go-file-rotatelogs
   version: 505c036604b3326a96097ca91865df30043093a5
-  subpackages:
-  - github.com/lestrrat/go-file-rotatelogs
 - name: github.com/lestrrat/go-server-starter-listener
   version: 00dd68592c85334ce94a28199ec7961352c0ba6d
-  subpackages:
-  - github.com/lestrrat/go-server-starter-listener
 - name: github.com/lestrrat/go-strftime
   version: 04ef93e285313c8978cbc7cad26d2aa7a9927451
-  subpackages:
-  - github.com/lestrrat/go-strftime
 - name: github.com/pkg/errors
   version: 248dadf4e9068a0b3e79f02ed0a610d935de5302
-  subpackages:
-  - github.com/pkg/errors
 - name: github.com/renstrom/shortuuid
   version: d728e00b727de969356736fabe7c6f405347a26c
-  subpackages:
-  - github.com/renstrom/shortuuid
 - name: github.com/satori/go.uuid
   version: b061729afc07e77a8aa4fad0a2fd840958f1942a
+testImports:
+- name: github.com/davecgh/go-spew
+  version: 04cdfd42973bb9c8589fd6a731800cf222fde1a9
   subpackages:
-  - github.com/satori/go.uuid
-devImports: []
+  - spew
+- name: github.com/pmezard/go-difflib
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  subpackages:
+  - difflib
+- name: github.com/stretchr/testify
+  version: f6abca593680b2315d2075e0f5e2a9751e3f431a
+  subpackages:
+  - assert

--- a/glide.yaml
+++ b/glide.yaml
@@ -4,4 +4,5 @@ import:
 - package: github.com/lestrrat/go-apache-logformat
 - package: github.com/lestrrat/go-server-starter-listener
 - package: github.com/renstrom/shortuuid
+testImport:
 - package: github.com/stretchr/testify

--- a/glide.yaml
+++ b/glide.yaml
@@ -4,3 +4,4 @@ import:
 - package: github.com/lestrrat/go-apache-logformat
 - package: github.com/lestrrat/go-server-starter-listener
 - package: github.com/renstrom/shortuuid
+- package: github.com/stretchr/testify

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -17,15 +17,15 @@ const (
 )
 
 // These headers won't be copied from original request to proxy request.
-var ignoredHeaderNames = []string{
-	"Connection",
-	"Keep-Alive",
-	"Proxy-Authenticate",
-	"Proxy-Authorization",
-	"Te",
-	"Trailers",
-	"Transfer-Encoding",
-	"Upgrade",
+var ignoredHeaderNames = map[string]struct{}{
+	"Connection":          struct{}{},
+	"Keep-Alive":          struct{}{},
+	"Proxy-Authenticate":  struct{}{},
+	"Proxy-Authorization": struct{}{},
+	"Te":                struct{}{},
+	"Trailers":          struct{}{},
+	"Transfer-Encoding": struct{}{},
+	"Upgrade":           struct{}{},
 }
 
 type ProxyStatus struct {
@@ -114,16 +114,14 @@ func (proxy *Proxy) copyRequest(originalRequest *http.Request) *http.Request {
 	proxyRequest.URL.Scheme = "http"
 	proxyRequest.URL.Path = originalRequest.URL.Path
 
-	// Copy all header fields.
+	// Copy all header fields except ignoredHeaderNames'.
 	for key, values := range originalRequest.Header {
+		if _, ok := ignoredHeaderNames[key]; ok {
+			continue
+		}
 		for _, value := range values {
 			proxyRequest.Header.Add(key, value)
 		}
-	}
-
-	// Remove ignored header fields.
-	for _, headerName := range ignoredHeaderNames {
-		proxyRequest.Header.Del(headerName)
 	}
 
 	// Append this machine's host name into X-Forwarded-For.

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -1,0 +1,86 @@
+package proxy
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	dummyProxy   *Proxy
+	dummyRequest *http.Request
+	dummyURL     *url.URL
+)
+
+func init() {
+	dummyProxy = &Proxy{
+		RequestConverter: func(r *http.Request, pr *http.Request, ps *ProxyStatus) {},
+	}
+	var err error
+	dummyRequest, err = createDummyRequest()
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func createDummyRequest() (*http.Request, error) {
+	dummyHeaders := http.Header{
+		"User-Agent":          {"dummy-client"},
+		"X-Chocon-Test-Value": {"6"},
+		// ignored headers
+		"Connection":          {"Keep-Alive"},
+		"Keep-Alive":          {"timeout=30, max=100"},
+		"Proxy-Authenticate":  {"Basic"},
+		"Proxy-Authorization": {"Basic dummy"},
+		"Te":                {"deflate"},
+		"Trailers":          {"Expires"},
+		"Transfer-Encoding": {"chunked"},
+		"Upgrade":           {"WebSocket"},
+	}
+	dummyURL = &url.URL{
+		Scheme: "http",
+		Path:   "/dummy",
+	}
+	req, err := http.NewRequest("GET", "/dummy", nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header = dummyHeaders
+	req.Close = true
+	req.Proto = "HTTP/1.0"
+	req.ProtoMajor = 1
+	req.ProtoMinor = 0
+	req.URL = dummyURL
+
+	return req, nil
+}
+
+func TestCopyRequest(t *testing.T) {
+	req := dummyProxy.copyRequest(dummyRequest)
+
+	assert.Equal(t, req.Proto, "HTTP/1.1")
+	assert.Equal(t, req.ProtoMajor, 1)
+	assert.Equal(t, req.ProtoMinor, 1)
+	assert.Equal(t, req.Close, false)
+	assert.Equal(t, req.URL.Scheme, "http")
+	assert.Equal(t, req.URL.Path, dummyURL.Path)
+
+	assert.Equal(t, req.Header["User-Agent"][0], "dummy-client")
+	assert.Equal(t, req.Header["X-Chocon-Test-Value"][0], "6")
+
+	for k, _ := range req.Header {
+		if _, ok := ignoredHeaderNames[k]; ok {
+			assert.Fail(t, fmt.Sprintf("header filed: %s must be removed", k))
+		}
+	}
+}
+
+func BenchmarkCopyRequest(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = dummyProxy.copyRequest(dummyRequest)
+	}
+}


### PR DESCRIPTION
And added the test and benchmark for **proxy.copyRequest()**.

## Before

```
$ go test -benchmem -benchtime 5s -bench .
BenchmarkCopyRequest-8           2000000              3376 ns/op            1655 B/op         15 allocs/op
PASS
ok      github.com/kazeburo/chocon/proxy        10.254s
```

## After

```
$ go test -benchmem -benchtime 5s -bench .
BenchmarkCopyRequest-8          10000000               970 ns/op             816 B/op          6 allocs/op
PASS
ok      github.com/kazeburo/chocon/proxy        10.710s
```