### PR TITLE
bumped version to 0.7.1.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.7.0
+VERSION=0.7.1
 LDFLAGS=-ldflags "-X main.Version=${VERSION}"
 TARGETS_NOVENDOR=$(shell glide novendor)
 


### PR DESCRIPTION
- bugfix: net.SplitHostPort raised error when r.Host did not have `:port` #10
- change variable names and the package names for golint #12
- optimize: reduced map-delete manipulation. #13