### PR TITLE
introduced go-httpstats.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -70,6 +70,14 @@
   revision = "ba3bf9c1d0421aa146564a632931730344f1f9f1"
 
 [[projects]]
+  digest = "1:246ab598a22ea9d50f46e65f655f78161a19822f6597268b02f04af998684807"
+  name = "github.com/montanaflynn/stats"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "1bf9dbcd8cbe1fdb75add3785b1d4a9a646269ab"
+  version = "0.3.0"
+
+[[projects]]
   digest = "1:cf31692c14422fa27c83a05292eb5cbe0fb2775972e8f1f8446a71549bd8980b"
   name = "github.com/pkg/errors"
   packages = ["."]
@@ -108,6 +116,14 @@
   pruneopts = "UT"
   revision = "9c60ba2751201bcc1079a467f46464936a0ef172"
   version = "0.1.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:74a950aa035c7f5dcff3c1c18b1098be107e4cf029120050686e2e31cb871029"
+  name = "go.mercari.io/go-httpstats"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "34fb78524912335cbb8c0bbef6358f0f2278795b"
 
 [[projects]]
   digest = "1:3c1a69cdae3501bf75e76d0d86dc6f2b0a7421bc205c0cb7b96b19eed464a34d"
@@ -152,6 +168,7 @@
     "github.com/renstrom/shortuuid",
     "github.com/stretchr/testify/assert",
     "go.mercari.io/go-dnscache",
+    "go.mercari.io/go-httpstats",
     "go.uber.org/zap",
   ]
   solver-name = "gps-cdcl"

--- a/chocon.go
+++ b/chocon.go
@@ -39,7 +39,7 @@ type cmdOpts struct {
 	ProxyReadTimeout int    `long:"proxy-read-timeout" default:"60" description:"timeout of reading response from upstream"`
 	Upstream         string `long:"upstream" default:"" description:"upstream server: http://upstream-server/"`
 	StatsBufsize     int    `long:"stsize" default:"1000" description:"buffer size for http stats"`
-	StatsSpfactor    int    `long:"spfactor" default:"1" description:"sampling factor for http stats"`
+	StatsSpfactor    int    `long:"spfactor" default:"3" description:"sampling factor for http stats"`
 }
 
 func addStatsHandler(h http.Handler, mw *statsHTTP.Metrics) http.Handler {

--- a/chocon.go
+++ b/chocon.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
+	"log"
 	"net"
 	"net/http"
 	"os"
@@ -16,6 +18,7 @@ import (
 	"github.com/lestrrat/go-apache-logformat"
 	"github.com/lestrrat/go-file-rotatelogs"
 	"github.com/lestrrat/go-server-starter-listener"
+	statsHTTP "go.mercari.io/go-httpstats"
 	"go.uber.org/zap"
 )
 
@@ -35,19 +38,29 @@ type cmdOpts struct {
 	WriteTimeout     int    `long:"write-timeout" default:"90" description:"timeout of writing response"`
 	ProxyReadTimeout int    `long:"proxy-read-timeout" default:"60" description:"timeout of reading response from upstream"`
 	Upstream         string `long:"upstream" default:"" description:"upstream server: http://upstream-server/"`
+	StatsBufsize     int    `long:"stsize" default:"1000" description:"buffer size for http stats"`
+	StatsSpfactor    int    `long:"spfactor" default:"1" description:"sampling factor for http stats"`
 }
 
-func addStatsHandler(h http.Handler) http.Handler {
+func addStatsHandler(h http.Handler, mw *statsHTTP.Metrics) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.Index(r.URL.Path, "/.api/stats") == 0 {
 			stats_api.Handler(w, r)
+		} else if strings.Index(r.URL.Path, "/.api/http-stats") == 0 {
+			d, err := mw.Data()
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
+			if err := json.NewEncoder(w).Encode(d); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
 		} else {
 			h.ServeHTTP(w, r)
 		}
 	})
 }
 
-func addLogHandler(h http.Handler, logDir string, logRotate int64, logger *zap.Logger) http.Handler {
+func wrapLogHandler(h http.Handler, logDir string, logRotate int64, logger *zap.Logger) http.Handler {
 	apacheLog, err := apachelog.New(`%h %l %u %t "%r" %>s %b "%v" %D %{X-Chocon-Req}i`)
 	if err != nil {
 		logger.Fatal("could not create apache logger", zap.Error(err))
@@ -82,6 +95,10 @@ func addLogHandler(h http.Handler, logDir string, logRotate int64, logger *zap.L
 	}
 
 	return apacheLog.Wrap(h, rl)
+}
+
+func wrapStatsHandler(h http.Handler, mw *statsHTTP.Metrics) http.Handler {
+	return mw.WrapHandleFunc(h)
 }
 
 func makeTransport(keepaliveConns int, proxyReadTimeout int) http.RoundTripper {
@@ -125,8 +142,13 @@ Compiler: %s %s
 	transport := makeTransport(opts.KeepaliveConns, opts.ProxyReadTimeout)
 	var handler http.Handler = proxy.New(&transport, upstream, logger)
 
-	handler = addStatsHandler(handler)
-	handler = addLogHandler(handler, opts.LogDir, opts.LogRotate, logger)
+	statsChocon, err := statsHTTP.NewCapa(opts.StatsBufsize, opts.StatsSpfactor)
+	if err != nil {
+		log.Fatal(err)
+	}
+	handler = addStatsHandler(handler, statsChocon)
+	handler = wrapLogHandler(handler, opts.LogDir, opts.LogRotate, logger)
+	handler = wrapStatsHandler(handler, statsChocon)
 
 	server := http.Server{
 		Handler:      handler,


### PR DESCRIPTION
go-httpstats reports stats for http.

 * response time average and 90/95/99 percentile value
 * number of requests of each http status code

## sample output

```json
{
  "request": {
    "count": 0,
    "status_count": {
      "200": 0,
      "400": 0,
      "401": 0,
      "403": 0,
      "404": 0,
      "500": 0,
      "501": 0,
      "502": 0,
      "503": 0,
      "504": 0
    }
  },
  "response": {
    "max_time": 0,
    "min_time": 0,
    "average_time": 0,
    "percentiled_time": {
      "90": 0,
      "95": 0,
      "99": 0
    }
  }
}
```