### PR TITLE
Introduced max conns per host

### DIFF
--- a/chocon.go
+++ b/chocon.go
@@ -34,7 +34,7 @@ type cmdOpts struct {
 	LogRotate        int64  `long:"access-log-rotate" default:"30" description:"Number of day before remove logs"`
 	Version          bool   `short:"v" long:"version" description:"Show version"`
 	KeepaliveConns   int    `short:"c" default:"2" long:"keepalive-conns" description:"maximum keepalive connections for upstream"`
-	MaxConnsPerHost  int    `long:"max-conns-per-host" default:"1000" description:"maximum connections per host"`
+	MaxConnsPerHost  int    `long:"max-conns-per-host" default:"0" description:"maximum connections per host"`
 	ReadTimeout      int    `long:"read-timeout" default:"30" description:"timeout of reading request"`
 	WriteTimeout     int    `long:"write-timeout" default:"90" description:"timeout of writing response"`
 	ProxyReadTimeout int    `long:"proxy-read-timeout" default:"60" description:"timeout of reading response from upstream"`
@@ -102,7 +102,7 @@ func wrapStatsHandler(h http.Handler, mw *statsHTTP.Metrics) http.Handler {
 	return mw.WrapHandleFunc(h)
 }
 
-func makeTransport(keepaliveConns int, proxyReadTimeout int, maxConnsPerHost int) http.RoundTripper {
+func makeTransport(keepaliveConns int, maxConnsPerHost int, proxyReadTimeout int) http.RoundTripper {
 	return &http.Transport{
 		// inherited http.DefaultTransport
 		Proxy: http.ProxyFromEnvironment,
@@ -115,8 +115,8 @@ func makeTransport(keepaliveConns int, proxyReadTimeout int, maxConnsPerHost int
 		ExpectContinueTimeout: 1 * time.Second,
 		// self-customized values
 		MaxIdleConnsPerHost:   keepaliveConns,
-		ResponseHeaderTimeout: time.Duration(proxyReadTimeout) * time.Second,
 		MaxConnsPerHost:       maxConnsPerHost,
+		ResponseHeaderTimeout: time.Duration(proxyReadTimeout) * time.Second,
 	}
 }
 
@@ -148,7 +148,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	transport := makeTransport(opts.KeepaliveConns, opts.ProxyReadTimeout, opts.MaxConnsPerHost)
+	transport := makeTransport(opts.KeepaliveConns, opts.MaxConnsPerHost, opts.ProxyReadTimeout)
 	var handler http.Handler = proxy.New(&transport, upstream, logger)
 
 	statsChocon, err := statsHTTP.NewCapa(opts.StatsBufsize, opts.StatsSpfactor)


### PR DESCRIPTION
MaxIdleConnsPerHost/サーバ側max keepalive request が十分な数がないと、有効に動かないっぽいが動いた