### PR TITLE
doc: updated how to build.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ go get -u github.com/kazeburo/chocon
 # Build
 
 ```
-make bundle
 make
 ```
 


### PR DESCRIPTION
The target of `bundle` is not necessary after merging #40.